### PR TITLE
Removes dependency on the homebrew cookbook and sets chef_version to ~> 12

### DIFF
--- a/libraries/resource_reattach_to_user_namespace_app.rb
+++ b/libraries/resource_reattach_to_user_namespace_app.rb
@@ -70,7 +70,6 @@ class Chef
       action :install do
         case new_resource.source
         when :homebrew
-          include_recipe 'homebrew'
           homebrew_package 'reattach-to-user-namespace' do
             version new_resource.version if new_resource.version
           end
@@ -112,7 +111,6 @@ class Chef
       action :upgrade do
         case new_resource.source
         when :homebrew
-          include_recipe 'homebrew'
           homebrew_package('reattach-to-user-namespace') { action :upgrade }
         when :direct
           new_resource.installed(true)
@@ -152,7 +150,6 @@ class Chef
       action :remove do
         case new_resource.source
         when :homebrew
-          include_recipe 'homebrew'
           homebrew_package('reattach-to-user-namespace') { action :remove }
         when :direct
           new_resource.installed(false)

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,6 +12,6 @@ source_url 'https://github.com/RoboticCheese/reattach-to-user-namespace-chef'
 issues_url 'https://github.com/RoboticCheese/reattach-to-user-namespace-chef' \
            '/issues'
 
-depends 'homebrew', '~> 2.1'
-
 supports 'mac_os_x'
+
+chef_verison '~> 12'

--- a/spec/resources/reattach_to_user_namespace_app/mac_os_x/10_10_spec.rb
+++ b/spec/resources/reattach_to_user_namespace_app/mac_os_x/10_10_spec.rb
@@ -44,10 +44,6 @@ describe 'resource_reattach_to_user_namespace_app::mac_os_x::10_10' do
     context 'the default source (:homebrew)' do
       cached(:chef_run) { converge }
 
-      it 'includes the homebrew default recipe' do
-        expect(chef_run).to include_recipe('homebrew')
-      end
-
       it 'installs RtUN via Homebrew' do
         expect(chef_run).to install_homebrew_package(
           'reattach-to-user-namespace'
@@ -241,10 +237,6 @@ describe 'resource_reattach_to_user_namespace_app::mac_os_x::10_10' do
 
     context 'the default source (:homebrew)' do
       cached(:chef_run) { converge }
-
-      it 'includes the homebrew default recipe' do
-        expect(chef_run).to include_recipe('homebrew')
-      end
 
       it 'removes RtUN via Homebrew' do
         expect(chef_run).to remove_homebrew_package(


### PR DESCRIPTION
The `homebrew_package` resource has been included in Chef since v12.0.

This change allows compatibility with v3 of the homebrew cookbook.

This explicitly requires Chef 12. I'm not sure if Chef 11 or older were supported by this cookbook.