### PR TITLE
Allows v4.x of the homebrew cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,6 @@ source_url 'https://github.com/RoboticCheese/reattach-to-user-namespace-chef'
 issues_url 'https://github.com/RoboticCheese/reattach-to-user-namespace-chef' \
            '/issues'
 
-depends 'homebrew', '< 4.0'
+depends 'homebrew', '< 5.0'
 
 supports 'mac_os_x'


### PR DESCRIPTION
v4.x does not include any incompatibilities with v3.x for installing brew packages.