### PR TITLE
Removes dependency on the homebrew cookbook and sets chef_version to ~> 12

### DIFF
--- a/libraries/resource_reattach_to_user_namespace_app.rb
+++ b/libraries/resource_reattach_to_user_namespace_app.rb
@@ -72,7 +72,6 @@ class Chef
       action :install do
         case new_resource.source
         when :homebrew
-          include_recipe 'homebrew'
           homebrew_package 'reattach-to-user-namespace' do
             version new_resource.version if new_resource.version
           end
@@ -114,7 +113,6 @@ class Chef
       action :upgrade do
         case new_resource.source
         when :homebrew
-          include_recipe 'homebrew'
           homebrew_package('reattach-to-user-namespace') { action :upgrade }
         when :direct
           new_resource.installed(true)
@@ -154,7 +152,6 @@ class Chef
       action :remove do
         case new_resource.source
         when :homebrew
-          include_recipe 'homebrew'
           homebrew_package('reattach-to-user-namespace') { action :remove }
         when :direct
           new_resource.installed(false)

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,6 @@ source_url 'https://github.com/RoboticCheese/reattach-to-user-namespace-chef'
 issues_url 'https://github.com/RoboticCheese/reattach-to-user-namespace-chef' \
            '/issues'
 
-depends 'homebrew', '< 5.0'
-
 supports 'mac_os_x'
+
+chef_verison '~> 12'

--- a/spec/resources/reattach_to_user_namespace_app/mac_os_x.rb
+++ b/spec/resources/reattach_to_user_namespace_app/mac_os_x.rb
@@ -17,10 +17,6 @@ shared_context 'resources::reattach_to_user_namespace_app::mac_os_x' do
       context 'all default properties' do
         include_context description
 
-        it 'includes the homebrew default recipe' do
-          expect(chef_run).to include_recipe('homebrew')
-        end
-
         it 'installs RtUN via Homebrew' do
           expect(chef_run).to install_homebrew_package(
             'reattach-to-user-namespace'
@@ -206,10 +202,6 @@ shared_context 'resources::reattach_to_user_namespace_app::mac_os_x' do
 
       context 'all default properties' do
         include_context description
-
-        it 'includes the homebrew default recipe' do
-          expect(chef_run).to include_recipe('homebrew')
-        end
 
         it 'removes RtUN via Homebrew' do
           expect(chef_run).to remove_homebrew_package(


### PR DESCRIPTION
The `homebrew_package` resource has been included in Chef since v12.0.

Chef 12 has already is [EOL](https://docs.chef.io/platforms.html#versions-and-status) so I think it's okay to require at least that.