### PR TITLE
Allows v5.x of the homebrew cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,6 @@ source_url 'https://github.com/RoboticCheese/reattach-to-user-namespace-chef'
 issues_url 'https://github.com/RoboticCheese/reattach-to-user-namespace-chef' \
            '/issues'
 
-depends 'homebrew', '< 5.0'
+depends 'homebrew', '< 6.0'
 
 supports 'mac_os_x'


### PR DESCRIPTION
In case you rather keep on depending on the homebrew cookbook this can be used instead of https://github.com/RoboticCheese/reattach-to-user-namespace-chef/pull/5.